### PR TITLE
Fix multi platform install

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -4,20 +4,20 @@ set -e
 set -o pipefail
 
 install_minio() {
-  local install_type=$1
-  local version=$2
-  local install_path=$3
+  local version install_path bin_install_path binary_path download_url
 
-  local bin_install_path="$install_path/bin"
-  local binary_path="$bin_install_path/minio"
-  local download_url=$(get_download_url $version)
+  version="${1}"
+  install_path="${2}"
+  bin_install_path="${install_path}/bin"
+  binary_path="${bin_install_path}/minio"
+  download_url=$(get_download_url "${version}")
 
   echo "Creating bin directory"
   mkdir -p "${bin_install_path}"
 
   echo "Downloading minio from ${download_url}"
-  curl --fail -Lo $binary_path $download_url
-  chmod +x $binary_path
+  curl --fail -Lo "${binary_path}" "${download_url}"
+  chmod +x "${binary_path}"
 }
 
 get_kernel() {
@@ -41,12 +41,14 @@ get_arch() {
 }
 
 get_download_url() {
-  local version=$1
-  local kernel="$(get_kernel)"
-  local arch="$(get_arch)"
-  local filename="minio.RELEASE.${version}"
+  local version kernel arch filename
+
+  version=$1
+  kernel="$(get_kernel)"
+  arch="$(get_arch)"
+  filename="minio.RELEASE.${version}"
 
   echo "https://dl.min.io/server/minio/release/${kernel}-${arch}/archive/${filename}"
 }
 
-install_minio $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
+install_minio "${ASDF_INSTALL_VERSION}" "${ASDF_INSTALL_PATH}"

--- a/bin/install
+++ b/bin/install
@@ -20,17 +20,33 @@ install_minio() {
   chmod +x $binary_path
 }
 
-get_arch() {
+get_kernel() {
   uname | tr '[:upper:]' '[:lower:]'
+}
+
+get_arch() {
+  raw_arch="$(uname -m)"
+
+  case ${raw_arch} in
+  x86_64)
+    echo "amd64"
+    ;;
+  armv7l)
+    echo "arm"
+    ;;
+  *)
+    echo "${raw_arch}"
+    ;;
+  esac
 }
 
 get_download_url() {
   local version=$1
+  local kernel="$(get_kernel)"
   local arch="$(get_arch)"
   local filename="minio.RELEASE.${version}"
 
-  echo "https://dl.min.io/server/minio/release/${arch}-amd64/archive/${filename}"
+  echo "https://dl.min.io/server/minio/release/${kernel}-${arch}/archive/${filename}"
 }
-
 
 install_minio $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
 cmd="curl -s https://dl.min.io/server/minio/release/linux-amd64/archive/"
-versions=$(eval $cmd | grep -Eo "minio\.RELEASE\.[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}Z" | sed -e "s/minio.RELEASE.//" | sort | uniq)
-echo $versions
+versions=$(eval "${cmd}" | grep -Eo "minio\.RELEASE\.[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}Z" | sed -e "s/minio.RELEASE.//" | sort | uniq)
+
+echo "${versions}"


### PR DESCRIPTION
Hi 👋 🙂

I was performing some `asdf` installs on my Raspberry Pi and noticed `bin/install` only supported the `amd64` architecture.  I updated to support Raspberry Pi 3/4 as well as continuing to support `amd64` 🙂

I also fixed some https://github.com/koalaman/shellcheck suggestions along the way.  Thanks for creating the plugin in the first place! ⭐ 