### PR TITLE
Add --fail to curl so it returns correct exit code

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -16,7 +16,7 @@ install_minio() {
   mkdir -p "${bin_install_path}"
 
   echo "Downloading minio from ${download_url}"
-  curl -Lo $binary_path $download_url
+  curl --fail -Lo $binary_path $download_url
   chmod +x $binary_path
 }
 


### PR DESCRIPTION
# Problem

Recently, a version of minio was 'yanked' (`2020-09-18T00-13-21Z`) but was briefly available so was added to a repo's `.tool-versions` file.  The `curl` command in `bin/install` did not return a non-zero exit code in the event the version was available, which lead to `2020-09-18T00-13-21Z` being installed but unusable:

```sh
$ asdf install minio 2020-09-18T00-13-21Z ; echo $?
Creating bin directory
Downloading minio from https://dl.min.io/server/minio/release/darwin-amd64/archive/minio.RELEASE.2020-09-18T00-13-21Z
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    14  100    14    0     0     20      0 --:--:-- --:--:-- --:--:--    20
0

$ ~/.asdf/installs/minio/2020-09-18T00-13-21Z/bin/minio
/Users/ash/.asdf/installs/minio/2020-09-18T00-13-21Z/bin/minio: line 1: 404: command not found

$ cat ~/.asdf/installs/minio/2020-09-18T00-13-21Z/bin/minio
404 Not Found
```

# Solution

Adding `--fail` to the curl command causes `curl` to exist with a non-zero exit code if the minio version does not exist which will stop `asdf` from installing a bad version:

```sh
$ asdf install minio 2020-09-18T00-13-21Z ; echo $?
Creating bin directory
Downloading minio from https://dl.min.io/server/minio/release/darwin-amd64/archive/minio.RELEASE.2020-09-18T00-13-21Z
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
1

$ ~/.asdf/installs/minio/2020-09-18T00-13-21Z/bin/minio
zsh: no such file or directory: /Users/ash/.asdf/installs/minio/2020-09-18T00-13-21Z/bin/minio
```