### PR TITLE
Support aarch64

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -31,7 +31,7 @@ get_arch() {
   x86_64)
     echo "amd64"
     ;;
-  armv7l)
+  armv7l|aarch64)
     echo "arm"
     ;;
   *)


### PR DESCRIPTION
This PR adds support for `aarch64` which is what `uname -m` returns when running  a 64bit OS on a Raspberry Pi 4 🙂