### PR TITLE
Ensure list is space-separated for asdf compatibility

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cmd="curl -s https://dl.min.io/server/minio/release/linux-amd64/archive/"
+cmd="curl -sL https://dl.min.io/server/minio/release/linux-amd64/archive/"
 versions=$(eval "${cmd}" | grep -Eo "minio\.RELEASE\.[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}Z" | sed -e "s/minio.RELEASE.//" | sort | uniq)
 
-echo "${versions}"
+echo ${versions}


### PR DESCRIPTION
`echo`'ing in to quotes is preventing a full list from being shown in `asdf` as it results in a new-line separated list. Additionally included `-L` for `curl` to respect redirects if the page is moved to a different location.