### PR TITLE
Fix installing on Apple Silicon with Rosetta

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -31,7 +31,7 @@ get_arch() {
   x86_64)
     echo "amd64"
     ;;
-  armv7l|aarch64)
+  armv7l|aarch64|arm64)
     echo "arm"
     ;;
   *)
@@ -47,6 +47,10 @@ get_download_url() {
   kernel="$(get_kernel)"
   arch="$(get_arch)"
   filename="minio.RELEASE.${version}"
+
+  if [ "$kernel-$arch" = "darwin-arm" ]; then
+    arch="amd64" # upstream doesn't have a binary compiled for Apple Silicon, use Rosetta 2.
+  fi
 
   echo "https://dl.min.io/server/minio/release/${kernel}-${arch}/archive/${filename}"
 }


### PR DESCRIPTION
Hello,

Here are the changes needed to be able to run `asdf install minio VERSION`. At the moment it does not look like upstream has a binary compiled for darwin arm64, so the script uses the amd64 version. The check is easy to remove once there is a correct binary.

The output of `uname -m` is `arm64` on my M1 Mac.